### PR TITLE
DEL: 移除失效博客链接，修复 Export.py 对无 RSS 条目的处理

### DIFF
--- a/Export.py
+++ b/Export.py
@@ -26,7 +26,10 @@ def handler():
                 if not val[0] == '[':
                     continue
                 title = re.findall(r'\[(.+?)\]',val)[0]
-                xmlUrl = re.findall(r'<(.+?)>',val)[0]
+                xmlUrls = re.findall(r'<(.+?)>',val)
+                if not xmlUrls:
+                    continue
+                xmlUrl = xmlUrls[0]
                 htmlUrl = re.findall(r'\((.+?)\)',val)[0]
                 handlerData.append('<outline text="{0}" title="{0}" type="rss" xmlUrl="{1}" htmlUrl="{2}"/>'.format(title,xmlUrl,htmlUrl))
             fs.close()

--- a/README.md
+++ b/README.md
@@ -21,14 +21,6 @@
 [Kevin Blog](http://zhowkev.in) | <http://zhowkev.in/rss>
 [阿毛的蛋疼地](http://www.xiangwangfeng.com) | <http://www.xiangwangfeng.com/atom.xml>
 [亚庆的 Blog](http://billwang1990.github.io) | <http://billwang1990.github.io/atom.xml>
-[Nonomori](http://nonomori.farbox.com) | <http://nonomori.farbox.com/feed>
-[Wonderffee's Blog](http://wonderffee.github.io) | <http://wonderffee.github.io/atom.xml>
-[I'm TualatriX](http://imtx.me) | <http://imtx.me/feed/latest/>
-[Cocoabit](http://blog.cocoabit.com) | <http://blog.cocoabit.com/rss/>
-[不会开机的男孩](http://studentdeng.github.io) | <http://studentdeng.github.io/atom.xml>
-[Nico](http://blog.inico.me) | <http://blog.inico.me/atom.xml>
-[阿峰的技术窝窝](http://hufeng825.github.io) | <http://hufeng825.github.io/atom.xml>
-[answer_huang](http://answerhuang.duapp.com) | <http://answerhuang.duapp.com/index.php/feed/>
 [webfrogs](http://blog.nswebfrog.com/) | <http://blog.nswebfrog.com/feed/>
 [代码手工艺人](http://joeyio.com) | <http://joeyio.com/atom.xml>
 [Lancy's Blog](http://gracelancy.com) | <http://gracelancy.com/atom.xml>

--- a/blogcn.opml
+++ b/blogcn.opml
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?><opml version="1.0"><head><title>导出订阅</title></head><body><outline text="ios" title="ios" >
 <outline text="OneV's Den" title="OneV's Den" type="rss" xmlUrl="http://onevcat.com/atom.xml" htmlUrl="http://onevcat.com"/>
 <outline text="一只魔法师的工坊" title="一只魔法师的工坊" type="rss" xmlUrl="http://blog.ibireme.com/feed/" htmlUrl="http://blog.ibireme.com/"/>
-<outline text="破船之家" title="破船之家" type="rss" xmlUrl="http://beyondvincent.com/atom.xml" htmlUrl="http://beyondvincent.com"/>
 <outline text="NSHipster" title="NSHipster" type="rss" xmlUrl="http://nshipster.cn/feed.xml" htmlUrl="http://nshipster.cn"/>
 <outline text="Limboy 无网不剩" title="Limboy 无网不剩" type="rss" xmlUrl="http://feeds.feedburner.com/lzyy" htmlUrl="http://limboy.me/"/>
 <outline text="唐巧的技术博客" title="唐巧的技术博客" type="rss" xmlUrl="http://blog.devtang.com/atom.xml" htmlUrl="http://blog.devtang.com"/>
 <outline text="Ted's Homepage" title="Ted's Homepage" type="rss" xmlUrl="http://wufawei.com/feed" htmlUrl="http://wufawei.com/"/>
 <outline text="sunnyxx的技术博客" title="sunnyxx的技术博客" type="rss" xmlUrl="http://blog.sunnyxx.com/atom.xml" htmlUrl="http://blog.sunnyxx.com/"/>
 <outline text="bang's blog" title="bang's blog" type="rss" xmlUrl="http://blog.cnbang.net/feed/" htmlUrl="http://blog.cnbang.net/"/>
+<outline text="破船之家" title="破船之家" type="rss" xmlUrl="http://beyondvincent.com/atom.xml" htmlUrl="http://beyondvincent.com"/>
 <outline text="Kevin Blog" title="Kevin Blog" type="rss" xmlUrl="http://zhowkev.in/rss" htmlUrl="http://zhowkev.in"/>
 <outline text="阿毛的蛋疼地" title="阿毛的蛋疼地" type="rss" xmlUrl="http://www.xiangwangfeng.com/atom.xml" htmlUrl="http://www.xiangwangfeng.com"/>
 <outline text="亚庆的 Blog" title="亚庆的 Blog" type="rss" xmlUrl="http://billwang1990.github.io/atom.xml" htmlUrl="http://billwang1990.github.io"/>
-<outline text="Nonomori" title="Nonomori" type="rss" xmlUrl="http://nonomori.farbox.com/feed" htmlUrl="http://nonomori.farbox.com"/>
-<outline text="Wonderffee's Blog" title="Wonderffee's Blog" type="rss" xmlUrl="http://wonderffee.github.io/atom.xml" htmlUrl="http://wonderffee.github.io"/>
-<outline text="I'm TualatriX" title="I'm TualatriX" type="rss" xmlUrl="http://imtx.me/feed/latest/" htmlUrl="http://imtx.me"/>
-<outline text="Cocoabit" title="Cocoabit" type="rss" xmlUrl="http://blog.cocoabit.com/rss/" htmlUrl="http://blog.cocoabit.com"/>
-<outline text="不会开机的男孩" title="不会开机的男孩" type="rss" xmlUrl="http://studentdeng.github.io/atom.xml" htmlUrl="http://studentdeng.github.io"/>
-<outline text="Nico" title="Nico" type="rss" xmlUrl="http://blog.inico.me/atom.xml" htmlUrl="http://blog.inico.me"/>
-<outline text="阿峰的技术窝窝" title="阿峰的技术窝窝" type="rss" xmlUrl="http://hufeng825.github.io/atom.xml" htmlUrl="http://hufeng825.github.io"/>
-<outline text="answer_huang" title="answer_huang" type="rss" xmlUrl="http://answerhuang.duapp.com/index.php/feed/" htmlUrl="http://answerhuang.duapp.com"/>
 <outline text="webfrogs" title="webfrogs" type="rss" xmlUrl="http://blog.nswebfrog.com/feed/" htmlUrl="http://blog.nswebfrog.com/"/>
 <outline text="代码手工艺人" title="代码手工艺人" type="rss" xmlUrl="http://joeyio.com/atom.xml" htmlUrl="http://joeyio.com"/>
 <outline text="Lancy's Blog" title="Lancy's Blog" type="rss" xmlUrl="http://gracelancy.com/atom.xml" htmlUrl="http://gracelancy.com"/>
@@ -48,5 +40,5 @@
 <outline text="雷纯锋的技术博客" title="雷纯锋的技术博客" type="rss" xmlUrl="http://blog.leichunfeng.com/atom.xml" htmlUrl="http://blog.leichunfeng.com"/>
 <outline text="向晨宇的技术博客" title="向晨宇的技术博客" type="rss" xmlUrl="http://iosxxx.com/atom.xml" htmlUrl="http://www.iosxxx.com/"/>
 <outline text="FengJian's Blog" title="FengJian's Blog" type="rss" xmlUrl="http://fengjian0106.github.io/atom.xml" htmlUrl="http://fengjian0106.github.io/"/>
-<outline text="未知文明" title="未知文明" type="rss" xmlUrl="https://www.xwenming.com/index.php/feed" htmlUrl="https://www.xwenming.com"/>
-<outline text="刘悦的技术博客" title="刘悦的技术博客" type="rss" xmlUrl="https://v3u.cn/sitemap.xml" htmlUrl="https://v3u.cn"/></outline></body></opml>
+<outline text="面向信仰编程" title="面向信仰编程" type="rss" xmlUrl="https://draveness.me/feed.xml" htmlUrl="https://draveness.me/"/>
+<outline text="Leo的专栏" title="Leo的专栏" type="rss" xmlUrl="https://blog.csdn.net/Hello_Hwc/rss/list" htmlUrl="https://leomobiledeveloper.blog.csdn.net/?t=1"/></outline></body></opml>


### PR DESCRIPTION
移除 8 个已失效的博客条目（参考 PR #35）：
- Wonderffee's Blog, I'm TualatriX, Cocoabit, 不会开机的男孩, Nico, 阿峰的技术窝窝（PR #35 标记为不再更新）
- Nonomori（FarBox 平台已关闭）
- answer_huang（百度 duapp 平台已下线）

同时修复 Export.py 在遇到 RSS 列为「无」的条目时崩溃的问题，
改为正确跳过这些条目。

https://claude.ai/code/session_01DeKsa52aovYZ4GHc9dXuNT